### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "s3-skipper"
   ],
   "author": "Ing. Jose Manuel Santibañez <jmsv23@gmail.com> (https://github.com/jmsv23)",
-  "repo": "jmsv23/s3-check-rename",
+  "repository": "jmsv23/s3-check-rename",
   "license": "MIT",
   "dependencies": {
     "aws-sdk": "^2.1.17",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,8 @@
     "s3-skipper"
   ],
   "author": "Ing. Jose Manuel Santibañez <jmsv23@gmail.com> (https://github.com/jmsv23)",
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/brentertz/scapegoat/blob/master/LICENSE-MIT"
-    }
-  ],
+  "repo": "jmsv23/s3-check-rename",
+  "license": "MIT",
   "dependencies": {
     "aws-sdk": "^2.1.17",
     "string": "^3.0.1"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
